### PR TITLE
fix: assertEach does not fail on empty array items

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ class assertWrapper extends Helper {
    * @param {string} message
    */
   assertEach(items, predicate, message) {
-    const failed = items.find(i => !predicate(i));
+    const failed = !items.every(i => predicate(i));
 
     if (failed) {
       assert.fail(`Item ${failed} don't satisfy predicate: ${predicate}: ${message}`);


### PR DESCRIPTION
The issue can be reproduced like this:

```
const values = ['a', '', 'c'];
I.assertEach(
  values,
  value => !!value,
  'List contains empty value'
);
```